### PR TITLE
Fixes #38: Starts each airfield station with a random information letter

### DIFF
--- a/crates/datis-cmd/src/main.rs
+++ b/crates/datis-cmd/src/main.rs
@@ -88,6 +88,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             position: Position::default(),
             runways: vec![String::from("09"), String::from("26")],
             traffic_freq: None,
+            info_ltr_offset: 0,
         }),
         rpc: None,
     };

--- a/crates/datis-module/Cargo.toml
+++ b/crates/datis-module/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2"
 log = "0.4"
 log4rs = "0.10"
 lua51-sys = { git = "https://github.com/rkusa/hlua51.git" }
+rand = "0.7.3"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -5,6 +5,7 @@ use datis_core::rpc::*;
 use datis_core::station::*;
 use datis_core::tts::TextToSpeechProvider;
 use hlua51::{Lua, LuaFunction, LuaTable};
+use rand::Rng;
 use regex::{Regex, RegexBuilder};
 
 pub struct Info {
@@ -90,6 +91,10 @@ pub fn extract(mut lua: Lua<'static>) -> Result<Info, anyhow::Error> {
             .call_with_args("Airdromes")
             .map_err(|_| new_lua_call_error("GetTerrainConfig"))?;
 
+
+        // Create a random generator for creating the information letter offset.
+        let mut rng = rand::thread_rng();
+
         // on Caucasus, airdromes start at the index 12, others start at 1; also hlua's table
         // iterator does not work for tables of tables, which is why we are just iterating
         // from 1 to 50 an check whether there is an airdrome table at this index or not
@@ -122,6 +127,7 @@ pub fn extract(mut lua: Lua<'static>) -> Result<Info, anyhow::Error> {
                         position: Position { x, y, alt: 0.0 },
                         runways,
                         traffic_freq: None,
+                        info_ltr_offset: rng.gen_range(0, 25),
                     },
                 );
             }


### PR DESCRIPTION
- When we create an `Airfield` station we'll initialize it with a random offset to begin the phonetic alphabet.