### PR TITLE
Update the srs crate to make it more useable as a full fledged srs client

### DIFF
--- a/crates/datis-core/src/lib.rs
+++ b/crates/datis-core/src/lib.rs
@@ -30,7 +30,7 @@ use futures::future::FutureExt;
 use futures::select;
 use futures::sink::SinkExt;
 use futures::stream::{SplitSink, StreamExt};
-use srs::{Client, VoiceStream};
+use srs::{Client, VoiceStream, message::Coalition};
 use tokio::runtime::{self, Runtime};
 use tokio::sync::{oneshot, RwLock};
 use tokio::time::delay_for;
@@ -247,7 +247,7 @@ async fn run(
     shutdown_signal: oneshot::Receiver<()>,
 ) -> Result<(), anyhow::Error> {
     let name = format!("ATIS {}", station.name);
-    let mut client = Client::new(&name, station.freq);
+    let mut client = Client::new(&name, station.freq, Coalition::Blue);
     match &station.transmitter {
         #[cfg(feature = "rpc")]
         Transmitter::Airfield(airfield) => {

--- a/crates/radio-station/src/radio_station.rs
+++ b/crates/radio-station/src/radio_station.rs
@@ -11,7 +11,7 @@ use futures::sink::SinkExt;
 use futures::stream::{SplitSink, SplitStream, StreamExt as FutStreamExt};
 use ogg::reading::PacketReader;
 use ogg_metadata::{AudioMetadata, OggFormat};
-use srs::message::LatLngPosition;
+use srs::message::{Coalition, LatLngPosition};
 use srs::{Client, VoiceStream};
 use tokio::sync::oneshot;
 use tokio::time::delay_for;
@@ -50,7 +50,7 @@ impl RadioStation {
         path: P,
         should_loop: bool,
     ) -> Result<(), anyhow::Error> {
-        let mut client = Client::new(&self.name, self.freq);
+        let mut client = Client::new(&self.name, self.freq, Coalition::Blue);
         client.set_position(self.position).await;
 
         let (_tx, rx) = oneshot::channel();

--- a/crates/srs/src/client.rs
+++ b/crates/srs/src/client.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::message::{create_sguid, GameMessage, LatLngPosition};
+use crate::message::{create_sguid, GameMessage, LatLngPosition, Coalition};
 use crate::voice_stream::{VoiceStream, VoiceStreamError};
+
 use futures::channel::mpsc;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::RwLock;
@@ -20,16 +21,18 @@ pub struct Client {
     freq: u64,
     pos: Arc<RwLock<LatLngPosition>>,
     unit: Option<UnitInfo>,
+    pub coalition: Coalition
 }
 
 impl Client {
-    pub fn new(name: &str, freq: u64) -> Self {
+    pub fn new(name: &str, freq: u64, coalition: Coalition) -> Self {
         Client {
             sguid: create_sguid(),
             name: name.to_string(),
             freq,
             pos: Arc::new(RwLock::new(LatLngPosition::default())),
             unit: None,
+            coalition
         }
     }
 

--- a/crates/srs/src/message.rs
+++ b/crates/srs/src/message.rs
@@ -232,7 +232,7 @@ pub struct Message {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GameMessage {
-    pub control: i32,
+    pub control: Option<i32>,
     pub name: String,
     pub lat_lng: LatLngPosition,
     pub ptt: bool,

--- a/crates/srs/src/message.rs
+++ b/crates/srs/src/message.rs
@@ -229,12 +229,12 @@ pub struct Message {
 }
 
 /// Data received from the in-game srs-plugin.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GameMessage {
     pub control: i32,
     pub name: String,
-    pub lat_lng_position: LatLngPosition,
+    pub lat_lng: LatLngPosition,
     pub ptt: bool,
     pub radios: Vec<Radio>,
     pub selected: i16,

--- a/crates/srs/src/voice_codec.rs
+++ b/crates/srs/src/voice_codec.rs
@@ -91,7 +91,7 @@ impl Decoder for VoiceCodec {
 
             assert_eq!(
                 len,
-                4 + len_audio_part as u64 + len_frequencies + 4 + 8 + 22
+                4 + len_audio_part as u64 + len_frequencies + 4 + 8 + 1 + 22 + 22
             );
 
             let mut audio_part = vec![0u8; len_audio_part as usize];

--- a/crates/srs/src/voice_stream.rs
+++ b/crates/srs/src/voice_stream.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use crate::client::Client;
 use crate::message::{
-    Client as MsgClient, Coalition, GameMessage, Message, MsgType, Radio, RadioInfo,
+    Client as MsgClient, GameMessage, Message, MsgType, Radio, RadioInfo,
     RadioSwitchControls,
 };
 use crate::messages_codec::{self, MessagesCodec};
@@ -333,7 +333,7 @@ async fn create_radio_update_message(client: &Client) -> Message {
         client: Some(MsgClient {
             client_guid: client.sguid().to_string(),
             name: Some(client.name().to_string()),
-            coalition: Coalition::Blue,
+            coalition: client.coalition,
             radio_info: Some(RadioInfo {
                 name: "DATIS Radios".to_string(),
                 ptt: false,
@@ -362,7 +362,7 @@ async fn create_update_message(client: &Client) -> Message {
         client: Some(MsgClient {
             client_guid: client.sguid().to_string(),
             name: Some(client.name().to_string()),
-            coalition: Coalition::Blue,
+            coalition: client.coalition,
             radio_info: None,
             lat_lng_position: Some(pos.clone()),
         }),
@@ -378,7 +378,7 @@ async fn create_sync_message(client: &Client) -> Message {
         client: Some(MsgClient {
             client_guid: client.sguid().to_string(),
             name: Some(client.name().to_string()),
-            coalition: Coalition::Blue,
+            coalition: client.coalition,
             radio_info: None,
             lat_lng_position: Some(pos.clone()),
         }),
@@ -395,7 +395,7 @@ fn radio_message_from_game(client: &Client, game_message: &GameMessage) -> Messa
         client: Some(MsgClient {
             client_guid: client.sguid().to_string(),
             name: Some(game_message.name.clone()),
-            coalition: Coalition::Blue,
+            coalition: client.coalition,
             radio_info: Some(RadioInfo {
                 name: game_message.name.clone(),
                 ptt: game_message.ptt,

--- a/crates/srs/src/voice_stream.rs
+++ b/crates/srs/src/voice_stream.rs
@@ -389,7 +389,7 @@ async fn create_sync_message(client: &Client) -> Message {
 }
 
 fn radio_message_from_game(client: &Client, game_message: &GameMessage) -> Message {
-    let pos = game_message.lat_lng_position.clone();
+    let pos = game_message.lat_lng.clone();
 
     Message {
         client: Some(MsgClient {


### PR DESCRIPTION
Hi. If you don't remember, I have a custom srs client https://gitlab.com/TheZoq2/srsrs which uses this projects `srs` crate to do most of the heavy listing.

This PR adds a few things which make that crate more useable:

- Support specifying a colaition. Defaults to Blue in all other crates as before
- Fix the name of the GameMessage `lat_long` field
- Fix an assertion that failed after a new update. I don't remember the meaning of those values, perhaps named constants should be used
- Add support for sending voice packets to the server

I *think* all crates will still build correctly, but I have some issues which are also present on master:

- datis-cmd fails with "Station does has no field named `rpc`"
- datis-core has 5 failed tests. Same tests as a fresh master
- doing `cargo test` in the root gives lua linker errors.