### PR TITLE
Allow parameters in any order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	cargo test --workspace --exclude datis
 
 test_debug:
-	cargo test -- --nocapture
+	cargo test --workspace --exclude datis -- --nocapture
 
 release:
 	cargo build --release --package datis

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -147,7 +147,7 @@ pub struct BroadcastConfig {
 
 pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> {
     let re = RegexBuilder::new(
-        r"^BROADCAST ([1-3]\d{2}(\.\d{1,3})?)(,[ ]?VOICE ([a-zA-Z-:]+))?:[ ]*(.+)$",
+        r"^BROADCAST ([1-3]\d{2}(\.\d{1,3})?)(.*): ([^:]+)$",
     )
     .case_insensitive(true)
     .build()

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -51,12 +51,10 @@ pub fn extract_atis_station_frequencies(situation: &str) -> HashMap<String, Stat
 }
 
 pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
-    let re = RegexBuilder::new(
-        r"^ATIS ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
+    let re = RegexBuilder::new(r"^ATIS ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
 
     let caps = re.captures(config).unwrap();
     let name = caps.get(1).unwrap().as_str().to_string();
@@ -67,40 +65,42 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
     let mut tts: Option<TextToSpeechProvider> = None;
     let mut info_ltr_override = None;
 
-    let rex_option = RegexBuilder::new(
-        r"([^ ]*) (.*)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
-    for token in config.split(",").skip(1){
+    let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
+    for token in config.split(",").skip(1) {
         let caps = rex_option.captures(token.trim()).unwrap();
         let option_key = caps.get(1).unwrap().as_str();
         let option_value = caps.get(2).map_or("", |m| m.as_str());
-        
+
         match option_key {
-            "TRAFFIC" => { 
+            "TRAFFIC" => {
                 if let Some(traffic_freq_hz) = option_value.parse::<f64>().ok() {
-                    traffic_freq = Some((traffic_freq_hz*1_000_000.0) as u64);
-                }else{
-                    log::warn!("Unable to extract ATIS station traffic frequency from {}", option_value);
+                    traffic_freq = Some((traffic_freq_hz * 1_000_000.0) as u64);
+                } else {
+                    log::warn!(
+                        "Unable to extract ATIS station traffic frequency from {}",
+                        option_value
+                    );
                 }
             }
             "VOICE" => {
                 if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
                     tts = Some(tts_provider);
-                }else{
+                } else {
                     log::warn!("Unable to extract Voice from {}", option_value);
                 }
             }
             "INFO" => {
-                info_ltr_override = caps.get(2).map_or(None, 
-                    |param| (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())));
+                info_ltr_override = caps.get(2).map_or(None, |param| {
+                    (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase()))
+                });
             }
-            _ => { 
+            _ => {
                 log::warn!("Unsupported ATIS station option {}", option_key);
             }
-          }
+        }
     }
 
     let result = StationConfig {
@@ -115,12 +115,10 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
 }
 
 pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
-    let re = RegexBuilder::new(
-        r"^CARRIER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
+    let re = RegexBuilder::new(r"^CARRIER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
 
     let caps = re.captures(config).unwrap();
     let name = caps.get(1).unwrap().as_str().to_string();
@@ -130,33 +128,32 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
     let mut tts: Option<TextToSpeechProvider> = None;
     let mut info_ltr_override = None;
 
-    let rex_option = RegexBuilder::new(
-        r"([^ ]*) (.*)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
-    for token in config.split(",").skip(1){
+    let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
+    for token in config.split(",").skip(1) {
         let caps = rex_option.captures(token.trim()).unwrap();
         let option_key = caps.get(1).unwrap().as_str();
         let option_value = caps.get(2).map_or("", |m| m.as_str());
-        
+
         match option_key {
             "VOICE" => {
                 if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
                     tts = Some(tts_provider);
-                }else{
+                } else {
                     log::warn!("Unable to extract Voice from {}", option_value);
                 }
             }
             "INFO" => {
-                info_ltr_override = caps.get(2).map_or(None, 
-                    |param| (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())));
+                info_ltr_override = caps.get(2).map_or(None, |param| {
+                    (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase()))
+                });
             }
-            _ => { 
+            _ => {
                 log::warn!("Unsupported CARRIER station option {}", option_key);
             }
-          }
+        }
     }
 
     let result = StationConfig {
@@ -178,12 +175,10 @@ pub struct BroadcastConfig {
 }
 
 pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> {
-    let re = RegexBuilder::new(
-        r"^BROADCAST ([1-3]\d{2}(\.\d{1,3})?)(.*): ([^:]+)$",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
+    let re = RegexBuilder::new(r"^BROADCAST ([1-3]\d{2}(\.\d{1,3})?)(.*): ([^:]+)$")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
 
     let caps = re.captures(config).unwrap();
     let freq = caps.get(1).unwrap();
@@ -192,40 +187,33 @@ pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> 
     let message = caps.get(4).unwrap().as_str().to_string();
 
     let mut tts: Option<TextToSpeechProvider> = None;
-    if options.is_some()
-    {
-        let rex_option = RegexBuilder::new(
-            r"([^ ]*) (.*)",
-        )
-        .case_insensitive(true)
-        .build()
-        .unwrap();
+    if options.is_some() {
+        let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
+            .case_insensitive(true)
+            .build()
+            .unwrap();
 
-        for token in options.unwrap().as_str().split(",").skip(1){
+        for token in options.unwrap().as_str().split(",").skip(1) {
             let caps = rex_option.captures(token.trim()).unwrap();
             let option_key = caps.get(1).unwrap().as_str();
             let option_value = caps.get(2).map_or("", |m| m.as_str());
-            
+
             match option_key {
                 "VOICE" => {
                     if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
                         tts = Some(tts_provider);
-                    }else{
+                    } else {
                         log::warn!("Unable to extract Voice from {}", option_value);
                     }
                 }
-                _ => { 
+                _ => {
                     log::warn!("Unsupported BROADCAST station option {}", option_key);
                 }
             }
         }
     }
 
-    let result = BroadcastConfig {
-        freq,
-        message,
-        tts,
-    };
+    let result = BroadcastConfig { freq, message, tts };
 
     Some(result)
 }
@@ -238,12 +226,10 @@ pub struct WetherStationConfig {
 }
 
 pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfig> {
-    let re = RegexBuilder::new(
-        r"^WEATHER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
+    let re = RegexBuilder::new(r"^WEATHER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
 
     let caps = re.captures(config).unwrap();
     let name = caps.get(1).unwrap().as_str().to_string();
@@ -251,36 +237,34 @@ pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfi
     let station_freq = (f64::from_str(station_freq.as_str()).unwrap() * 1_000_000.0) as u64;
 
     let mut tts: Option<TextToSpeechProvider> = None;
-    
-    let rex_option = RegexBuilder::new(
-        r"([^ ]*) (.*)",
-    )
-    .case_insensitive(true)
-    .build()
-    .unwrap();
-    for token in config.split(",").skip(1){
+
+    let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
+        .case_insensitive(true)
+        .build()
+        .unwrap();
+    for token in config.split(",").skip(1) {
         let caps = rex_option.captures(token.trim()).unwrap();
         let option_key = caps.get(1).unwrap().as_str();
         let option_value = caps.get(2).map_or("", |m| m.as_str());
-        
+
         match option_key {
             "VOICE" => {
                 if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
                     tts = Some(tts_provider);
-                }else{
+                } else {
                     log::warn!("Unable to extract Voice from {}", option_value);
                 }
             }
-            _ => { 
+            _ => {
                 log::warn!("Unsupported WEATHER station option {}", option_key);
             }
-          }
+        }
     }
 
     let result = WetherStationConfig {
         name: name,
         freq: station_freq,
-        tts
+        tts,
     };
 
     Some(result)

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -192,10 +192,8 @@ pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> 
     let message = caps.get(4).unwrap().as_str().to_string();
 
     let mut tts: Option<TextToSpeechProvider> = None;
-
     if options.is_some()
     {
-        println!("Considering broadcast option {:?} ", options.unwrap().as_str());
         let rex_option = RegexBuilder::new(
             r"([^ ]*) (.*)",
         )

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -64,7 +64,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
     let atis_freq = (f64::from_str(atis_freq.as_str()).unwrap() * 1_000_000.0) as u64;
 
     let mut traffic_freq: Option<u64> = None;
-    let mut tts = None;
+    let mut tts: Option<TextToSpeechProvider> = None;
     let mut info_ltr_override = None;
 
     let rex_option = RegexBuilder::new(
@@ -87,12 +87,13 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
                 }
             }
             "VOICE" => {
-                // TODO: Log an error if this failes, same as the TRAFFIC option
-                tts = caps.get(2).map_or(None, 
-                         |s| TextToSpeechProvider::from_str(s.as_str()).ok());
+                if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                    tts = Some(tts_provider);
+                }else{
+                    log::warn!("Unable to extract Voice from {}", option_value);
+                }
             }
-            "INFO" => { 
-                // TODO: Log an error if this failes, same as the TRAFFIC option
+            "INFO" => {
                 info_ltr_override = caps.get(2).map_or(None, 
                     |param| (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())));
             }

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -56,7 +56,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
         .build()
         .unwrap();
 
-    let caps = re.captures(config).unwrap();
+    let caps = re.captures(config)?;
     let name = caps.get(1).unwrap().as_str().to_string();
     let atis_freq = caps.get(2).unwrap();
     let atis_freq = (f64::from_str(atis_freq.as_str()).unwrap() * 1_000_000.0) as u64;
@@ -120,7 +120,7 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
         .build()
         .unwrap();
 
-    let caps = re.captures(config).unwrap();
+    let caps = re.captures(config)?;
     let name = caps.get(1).unwrap().as_str().to_string();
     let atis_freq = caps.get(2).unwrap();
     let atis_freq = (f64::from_str(atis_freq.as_str()).unwrap() * 1_000_000.0) as u64;
@@ -180,7 +180,7 @@ pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> 
         .build()
         .unwrap();
 
-    let caps = re.captures(config).unwrap();
+    let caps = re.captures(config)?;
     let freq = caps.get(1).unwrap();
     let options = caps.get(3);
     let freq = (f64::from_str(freq.as_str()).unwrap() * 1_000_000.0) as u64;
@@ -231,7 +231,7 @@ pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfi
         .build()
         .unwrap();
 
-    let caps = re.captures(config).unwrap();
+    let caps = re.captures(config)?;
     let name = caps.get(1).unwrap().as_str().to_string();
     let station_freq = caps.get(2).unwrap();
     let station_freq = (f64::from_str(station_freq.as_str()).unwrap() * 1_000_000.0) as u64;
@@ -534,6 +534,29 @@ mod test {
                 }),
                 info_ltr_override: None,
             })
+        );
+    }
+
+    #[test]
+    fn test_complete_garbge() {
+        assert_eq!(
+            extract_atis_station_config("not an atis station at all"),
+            None
+        );
+
+        assert_eq!(
+            extract_carrier_station_config("not a carrer station at all"),
+            None
+        );
+
+        assert_eq!(
+            extract_custom_broadcast_config("not a custom broadcast at all"),
+            None
+        );
+
+        assert_eq!(
+            extract_weather_station_config("not a weather station at all"),
+            None
         );
     }
 

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -76,7 +76,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
 
         match option_key {
             "TRAFFIC" => {
-                if let Some(traffic_freq_hz) = option_value.parse::<f64>().ok() {
+                if let Ok(traffic_freq_hz) = option_value.parse::<f64>() {
                     traffic_freq = Some((traffic_freq_hz * 1_000_000.0) as u64);
                 } else {
                     log::warn!(
@@ -86,7 +86,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
                 }
             }
             "VOICE" => {
-                if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                if let Ok(tts_provider) = TextToSpeechProvider::from_str(option_value) {
                     tts = Some(tts_provider);
                 } else {
                     log::warn!("Unable to extract Voice from {}", option_value);
@@ -139,7 +139,7 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
 
         match option_key {
             "VOICE" => {
-                if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                if let Ok(tts_provider) = TextToSpeechProvider::from_str(option_value) {
                     tts = Some(tts_provider);
                 } else {
                     log::warn!("Unable to extract Voice from {}", option_value);
@@ -200,7 +200,7 @@ pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> 
 
             match option_key {
                 "VOICE" => {
-                    if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                    if let Ok(tts_provider) = TextToSpeechProvider::from_str(option_value) {
                         tts = Some(tts_provider);
                     } else {
                         log::warn!("Unable to extract Voice from {}", option_value);
@@ -249,7 +249,7 @@ pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfi
 
         match option_key {
             "VOICE" => {
-                if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                if let Ok(tts_provider) = TextToSpeechProvider::from_str(option_value) {
                     tts = Some(tts_provider);
                 } else {
                     log::warn!("Unable to extract Voice from {}", option_value);

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -94,7 +94,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
             }
             "INFO" => {
                 info_ltr_override = caps.get(2).map_or(None, |param| {
-                    (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase()))
+                    Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())
                 });
             }
             _ => {
@@ -147,7 +147,7 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
             }
             "INFO" => {
                 info_ltr_override = caps.get(2).map_or(None, |param| {
-                    (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase()))
+                    Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())
                 });
             }
             _ => {

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -82,16 +82,10 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
         
         match option_key {
             "TRAFFIC" => { 
-                //println!("Processing traffic {}", option_value);
-                /*traffic_freq = 
-                    option_value.map_or(None, 
-                        |freq| Some((f64::from_str(freq.as_str()).unwrap() * 1_000_000.0) as u64));*/
-                //traffic_freq = option_value.filter_map(|s| s.parse::<f64>().ok()).collect::<Vec<_>>();
-                let traffic_freq_hz = option_value.parse::<f64>().ok();
-                if traffic_freq_hz.is_none() {
-                    log::warn!("Unable to extract ATIS station traffic frequency from {}", option_value);//option_value.unwrap().as_str());
+                if let Some(traffic_freq_hz) = option_value.parse::<f64>().ok() {
+                    traffic_freq = Some((traffic_freq_hz*1_000_000.0) as u64);
                 }else{
-                    traffic_freq = Some((traffic_freq_hz.unwrap()*1_000_000.0) as u64);
+                    log::warn!("Unable to extract ATIS station traffic frequency from {}", option_value);
                 }
             }
             "VOICE" => {

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -528,7 +528,7 @@ mod test {
     }
 
     #[test]
-    fn test_complete_garbge() {
+    fn test_complete_garbage() {
         assert_eq!(
             extract_atis_station_config("not an atis station at all"),
             None

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -128,14 +128,11 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
     let mut tts: Option<TextToSpeechProvider> = None;
     let mut info_ltr_override = None;
 
-    let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
-        .case_insensitive(true)
-        .build()
-        .unwrap();
     for token in config.split(",").skip(1) {
-        let caps = rex_option.captures(token.trim()).unwrap();
-        let option_key = caps.get(1).unwrap().as_str();
-        let option_value = caps.get(2).map_or("", |m| m.as_str());
+        let token = token.trim();
+        let (option_key, option_value) = token.split_at(token.find(' ').unwrap_or(token.len()));
+        let option_key = option_key.trim();
+        let option_value = option_value.trim();
 
         match option_key {
             "VOICE" => {
@@ -188,15 +185,11 @@ pub fn extract_custom_broadcast_config(config: &str) -> Option<BroadcastConfig> 
 
     let mut tts: Option<TextToSpeechProvider> = None;
     if options.is_some() {
-        let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
-            .case_insensitive(true)
-            .build()
-            .unwrap();
-
         for token in options.unwrap().as_str().split(",").skip(1) {
-            let caps = rex_option.captures(token.trim()).unwrap();
-            let option_key = caps.get(1).unwrap().as_str();
-            let option_value = caps.get(2).map_or("", |m| m.as_str());
+            let token = token.trim();
+            let (option_key, option_value) = token.split_at(token.find(' ').unwrap_or(token.len()));
+            let option_key = option_key.trim();
+            let option_value = option_value.trim();
 
             match option_key {
                 "VOICE" => {
@@ -238,14 +231,11 @@ pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfi
 
     let mut tts: Option<TextToSpeechProvider> = None;
 
-    let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
-        .case_insensitive(true)
-        .build()
-        .unwrap();
     for token in config.split(",").skip(1) {
-        let caps = rex_option.captures(token.trim()).unwrap();
-        let option_key = caps.get(1).unwrap().as_str();
-        let option_value = caps.get(2).map_or("", |m| m.as_str());
+        let token = token.trim();
+        let (option_key, option_value) = token.split_at(token.find(' ').unwrap_or(token.len()));
+        let option_key = option_key.trim();
+        let option_value = option_value.trim();
 
         match option_key {
             "VOICE" => {

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -241,24 +241,51 @@ pub struct WetherStationConfig {
 
 pub fn extract_weather_station_config(config: &str) -> Option<WetherStationConfig> {
     let re = RegexBuilder::new(
-        r"^WEATHER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)(,[ ]?VOICE ([a-zA-Z-:]+))?$",
+        r"^WEATHER ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)",
     )
     .case_insensitive(true)
     .build()
     .unwrap();
-    re.captures(config).map(|caps| {
-        let name = caps.get(1).unwrap().as_str();
-        let freq = caps.get(2).unwrap().as_str();
-        let freq = (f64::from_str(freq).unwrap() * 1_000_000.0) as u64;
-        let tts = caps
-            .get(5)
-            .and_then(|s| TextToSpeechProvider::from_str(s.as_str()).ok());
-        WetherStationConfig {
-            name: name.to_string(),
-            freq,
-            tts,
-        }
-    })
+
+    let caps = re.captures(config).unwrap();
+    let name = caps.get(1).unwrap().as_str().to_string();
+    let station_freq = caps.get(2).unwrap();
+    let station_freq = (f64::from_str(station_freq.as_str()).unwrap() * 1_000_000.0) as u64;
+
+    let mut tts: Option<TextToSpeechProvider> = None;
+    
+    let rex_option = RegexBuilder::new(
+        r"([^ ]*) (.*)",
+    )
+    .case_insensitive(true)
+    .build()
+    .unwrap();
+    for token in config.split(",").skip(1){
+        let caps = rex_option.captures(token.trim()).unwrap();
+        let option_key = caps.get(1).unwrap().as_str();
+        let option_value = caps.get(2).map_or("", |m| m.as_str());
+        
+        match option_key {
+            "VOICE" => {
+                if let Some(tts_provider) = TextToSpeechProvider::from_str(option_value).ok() {
+                    tts = Some(tts_provider);
+                }else{
+                    log::warn!("Unable to extract Voice from {}", option_value);
+                }
+            }
+            _ => { 
+                log::warn!("Unsupported WEATHER station option {}", option_key);
+            }
+          }
+    }
+
+    let result = WetherStationConfig {
+        name: name,
+        freq: station_freq,
+        tts
+    };
+
+    Some(result)
 }
 
 #[cfg(test)]

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -67,8 +67,6 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
     let mut tts = None;
     let mut info_ltr_override = None;
 
-    // Or, this does make a good case for nom: https://stevedonovan.github.io/rust-gentle-intro/nom-intro.html
-
     let rex_option = RegexBuilder::new(
         r"([^ ]*) (.*)",
     )
@@ -89,10 +87,12 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
                 }
             }
             "VOICE" => {
+                // TODO: Log an error if this failes, same as the TRAFFIC option
                 tts = caps.get(2).map_or(None, 
                          |s| TextToSpeechProvider::from_str(s.as_str()).ok());
             }
             "INFO" => { 
+                // TODO: Log an error if this failes, same as the TRAFFIC option
                 info_ltr_override = caps.get(2).map_or(None, 
                     |param| (Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())));
             }


### PR DESCRIPTION
Used a new style of regex parsing to be more flexible about how options are parsed for each object type.  This sets the ground work for more flexibility to define new options going forward.