### PR TITLE
Allow options in briefing txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Add a static unit per ATIS station to the mission, e.g. a communication tower (t
 (`{}` denotes a part that has to be replaced with a proper value and `[]` denotes an optional part)
 
 ```
-ATIS {Airfield} {ATIS Frequency}[, TRAFFIC {TRAFFIC Frequency}][, VOICE {VOICE NAME}, INFO {OVERRIDE INFO LETTER}]
+ATIS {Airfield} {ATIS Frequency}[, TRAFFIC {TRAFFIC Frequency}][, VOICE {VOICE NAME}][, INFO {OVERRIDE INFO LETTER}][, ACTIVE {ACTIVE RUNWAY OVERRIDE}]
 ```
 
 Your choice for `{VOICE NAME}` depicts which cloud provider is used for a particular ATIS station.
@@ -115,6 +115,8 @@ The default can be changed in the DCS SPECIAL settings for DATIS.
 
 `OVERRIDE INFO LETTER` Allows you to override the dynamic rotating selection of the ATIS information letter in your mission requires a specific and constant value.
 
+`ACTIVE RUNWAY OVERRIDE` can be used if the SPINS for the airfield differ from the prevailing winds and you want to override the calculated active runway.
+
 Examples:
 
 ```
@@ -125,7 +127,7 @@ ATIS Kutaisi 251.000, TRAFFIC 252.000, VOICE en-US-Standard-E
 ATIS Kutaisi 251.000, TRAFFIC 252.000, VOICE GC:en-US-Wavenet-B
 ATIS Kutaisi 251.000, TRAFFIC 252.000, VOICE AWS:Nicole
 ATIS Kutaisi 251.000, TRAFFIC 252.000, VOICE WIN
-ATIS Kutaisi 251.000, TRAFFIC 252.000, INFO Q
+ATIS Kutaisi 251.000, TRAFFIC 252.000, INFO Q, ACTIVE 21L
 ```
 
 ![Example](./docs/static.jpg)

--- a/crates/datis-cmd/src/main.rs
+++ b/crates/datis-cmd/src/main.rs
@@ -87,6 +87,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             traffic_freq: None,
             info_ltr_offset: 0,
             info_ltr_override: None,
+            active_rwy_override: None
         }),
     };
     let mut datis = Datis::new(vec![station])?;

--- a/crates/datis-cmd/src/main.rs
+++ b/crates/datis-cmd/src/main.rs
@@ -87,7 +87,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             traffic_freq: None,
             info_ltr_offset: 0,
             info_ltr_override: None,
-            active_rwy_override: None
+            active_rwy_override: None,
         }),
     };
     let mut datis = Datis::new(vec![station])?;

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -31,7 +31,7 @@ pub fn extract_atis_station_frequencies(situation: &str) -> HashMap<String, Stat
                     traffic: None,
                     tts: None,
                     info_ltr_override: None,
-                    active_rwy_override: None
+                    active_rwy_override: None,
                 },
             )
         })
@@ -101,9 +101,9 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
                 });
             }
             "ACTIVE" => {
-                active_rwy_override = caps.get(2).map_or(None, |param| {
-                    Some(param.as_str().into())
-                });
+                active_rwy_override = caps
+                    .get(2)
+                    .map_or(None, |param| Some(param.as_str().into()));
             }
             _ => {
                 log::warn!("Unsupported ATIS station option {}", option_key);

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -553,7 +553,7 @@ mod test {
     }
 
     #[test]
-    fn test_complete_garbge() {
+    fn test_complete_garbage() {
         assert_eq!(
             extract_atis_station_config("not an atis station at all"),
             None

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -324,6 +324,35 @@ mod test {
     }
 
     #[test]
+    fn test_advanced_mission_descriptiopn_extraction() {
+        let freqs = extract_stationc_config_from_mission_description(
+            r#"Welcome to my mission!
+            It's not a real mission, but rather a chance to test the mission extraction
+            logic in datis!
+
+            ATIS Batumi 131.5, INFO T, ACTIVE 12
+        "#,
+        );
+
+        assert_eq!(
+            freqs,
+            vec![(
+                "Batumi".to_string(),
+                StationConfig {
+                    name: "Batumi".to_string(),
+                    atis: 131_500_000,
+                    traffic: None,
+                    tts: None,
+                    info_ltr_override: Some('T'),
+                    active_rwy_override: Some("12".to_string()),
+                }
+            )]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
     fn test_atis_config_extraction() {
         assert_eq!(
             extract_atis_station_config("ATIS Kutaisi 251"),

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -11,6 +11,7 @@ pub struct StationConfig {
     pub traffic: Option<u64>,
     pub tts: Option<TextToSpeechProvider>,
     pub info_ltr_override: Option<char>,
+    pub active_rwy_override: Option<String>,
 }
 
 pub fn extract_atis_station_frequencies(situation: &str) -> HashMap<String, StationConfig> {
@@ -30,6 +31,7 @@ pub fn extract_atis_station_frequencies(situation: &str) -> HashMap<String, Stat
                     traffic: None,
                     tts: None,
                     info_ltr_override: None,
+                    active_rwy_override: None
                 },
             )
         })
@@ -64,6 +66,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
     let mut traffic_freq: Option<u64> = None;
     let mut tts: Option<TextToSpeechProvider> = None;
     let mut info_ltr_override = None;
+    let mut active_rwy_override = None;
 
     let rex_option = RegexBuilder::new(r"([^ ]*) (.*)")
         .case_insensitive(true)
@@ -97,6 +100,11 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
                     Some(param.as_str().chars().next().unwrap().to_ascii_uppercase())
                 });
             }
+            "ACTIVE" => {
+                active_rwy_override = caps.get(2).map_or(None, |param| {
+                    Some(param.as_str().into())
+                });
+            }
             _ => {
                 log::warn!("Unsupported ATIS station option {}", option_key);
             }
@@ -109,6 +117,7 @@ pub fn extract_atis_station_config(config: &str) -> Option<StationConfig> {
         traffic: traffic_freq,
         tts,
         info_ltr_override: info_ltr_override,
+        active_rwy_override: active_rwy_override,
     };
 
     Some(result)
@@ -159,6 +168,7 @@ pub fn extract_carrier_station_config(config: &str) -> Option<StationConfig> {
         traffic: None,
         tts,
         info_ltr_override: info_ltr_override,
+        active_rwy_override: None,
     };
 
     Some(result)
@@ -288,6 +298,7 @@ mod test {
                         traffic: None,
                         tts: None,
                         info_ltr_override: None,
+                        active_rwy_override: None,
                     }
                 ),
                 (
@@ -298,6 +309,7 @@ mod test {
                         traffic: Some(255_000_000),
                         tts: None,
                         info_ltr_override: None,
+                        active_rwy_override: None,
                     }
                 ),
                 (
@@ -308,6 +320,7 @@ mod test {
                         traffic: None,
                         tts: None,
                         info_ltr_override: None,
+                        active_rwy_override: None,
                     }
                 )
             ]
@@ -326,6 +339,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -337,6 +351,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -348,6 +363,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -359,6 +375,7 @@ mod test {
                 traffic: Some(123_450_000),
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -373,7 +390,8 @@ mod test {
                 tts: Some(TextToSpeechProvider::GoogleCloud {
                     voice: gcloud::VoiceKind::StandardE
                 }),
-                info_ltr_override: Some('Q')
+                info_ltr_override: Some('Q'),
+                active_rwy_override: None,
             })
         );
 
@@ -389,6 +407,7 @@ mod test {
                     voice: gcloud::VoiceKind::StandardE
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -402,6 +421,7 @@ mod test {
                     voice: gcloud::VoiceKind::StandardE
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -413,6 +433,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -425,6 +446,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -437,6 +459,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
     }
@@ -451,6 +474,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -462,6 +486,7 @@ mod test {
                 traffic: None,
                 tts: None,
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -475,6 +500,7 @@ mod test {
                     voice: gcloud::VoiceKind::StandardE
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
     }
@@ -491,6 +517,7 @@ mod test {
                     voice: gcloud::VoiceKind::StandardD
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
 
@@ -504,6 +531,7 @@ mod test {
                     voice: aws::VoiceKind::Brian
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
     }
@@ -523,6 +551,7 @@ mod test {
                     voice: gcloud::VoiceKind::StandardE
                 }),
                 info_ltr_override: None,
+                active_rwy_override: None,
             })
         );
     }
@@ -547,6 +576,21 @@ mod test {
         assert_eq!(
             extract_weather_station_config("not a weather station at all"),
             None
+        );
+    }
+
+    #[test]
+    fn test_active_rwy_override() {
+        assert_eq!(
+            extract_atis_station_config("ATIS Kutaisi 131.400, ACTIVE 21L"),
+            Some(StationConfig {
+                name: "Kutaisi".to_string(),
+                atis: 131_400_000,
+                traffic: None,
+                tts: None,
+                info_ltr_override: None,
+                active_rwy_override: Some("21L".to_string()),
+            })
         );
     }
 

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -14,40 +14,25 @@ pub struct StationConfig {
     pub active_rwy_override: Option<String>,
 }
 
-pub fn extract_atis_station_frequencies(situation: &str) -> HashMap<String, StationConfig> {
-    // extract ATIS stations and frequencies
-    let re = Regex::new(r"ATIS ([a-zA-Z- ]+) ([1-3]\d{2}(\.\d{1,3})?)").unwrap();
-    let mut stations: HashMap<String, StationConfig> = re
+pub fn extract_stationc_config_from_mission_description(situation: &str) -> HashMap<String, StationConfig> {
+    // extract ATIS stations from mission description
+    let re = Regex::new(r"(ATIS .*)").unwrap();
+    let stations: HashMap<String, StationConfig> = re
         .captures_iter(situation)
         .map(|caps| {
-            let name = caps.get(1).unwrap().as_str().to_string();
-            let freq = caps.get(2).unwrap().as_str();
-            let freq = (f32::from_str(freq).unwrap() * 1_000_000.0) as u64;
-            (
-                name.clone(),
-                StationConfig {
-                    name,
-                    atis: freq,
-                    traffic: None,
-                    tts: None,
-                    info_ltr_override: None,
-                    active_rwy_override: None,
-                },
-            )
+            let atis_line = caps.get(1).unwrap().as_str();
+            let station = extract_atis_station_config(atis_line);
+            station
         })
+        .flatten()
+        .map(|station|
+        (
+            station.name.clone(),
+            station,
+        ))
         .collect();
 
-    // extract optional traffic frequencies
-    let re = Regex::new(r"TRAFFIC ([a-zA-Z-]+) ([1-3]\d{2}(\.\d{1,3})?)").unwrap();
-    for caps in re.captures_iter(situation) {
-        let name = caps.get(1).unwrap().as_str();
-        let freq = caps.get(2).unwrap().as_str();
-        let freq = (f32::from_str(freq).unwrap() * 1_000_000.0) as u64;
-
-        if let Some(freqs) = stations.get_mut(name) {
-            freqs.traffic = Some(freq);
-        }
-    }
+        // Ok, this "works", but missed that it needs to combine multiple lines. i.e the TRAFFIC Batumi... part into the SAME station.. Hmmmm
 
     stations
 }
@@ -276,8 +261,8 @@ mod test {
     use crate::tts::{aws, gcloud, TextToSpeechProvider};
 
     #[test]
-    fn test_mission_situation_extraction() {
-        let freqs = extract_atis_station_frequencies(
+    fn test_mission_descriptiopn_extraction() {
+        let freqs = extract_stationc_config_from_mission_description(
             r#"
             ATIS Mineralnye Vody 251.000
             ATIS Batumi 131.5

--- a/crates/datis-core/src/extract.rs
+++ b/crates/datis-core/src/extract.rs
@@ -14,7 +14,9 @@ pub struct StationConfig {
     pub active_rwy_override: Option<String>,
 }
 
-pub fn extract_stationc_config_from_mission_description(situation: &str) -> HashMap<String, StationConfig> {
+pub fn extract_stationc_config_from_mission_description(
+    situation: &str,
+) -> HashMap<String, StationConfig> {
     // extract ATIS stations from mission description
     let re = Regex::new(r"(ATIS .*)").unwrap();
     let mut stations: HashMap<String, StationConfig> = re
@@ -25,25 +27,21 @@ pub fn extract_stationc_config_from_mission_description(situation: &str) -> Hash
             station
         })
         .flatten()
-        .map(|station|
-        (
-            station.name.clone(),
-            station,
-        ))
+        .map(|station| (station.name.clone(), station))
         .collect();
 
-        // Some "legacy" functionality which allowed specifyin TRAFFIC options on separate lines
-        // extract optional traffic frequencies
-        let re = Regex::new(r"TRAFFIC ([a-zA-Z-]+) ([1-3]\d{2}(\.\d{1,3})?)").unwrap();
-        for caps in re.captures_iter(situation) {
-            let name = caps.get(1).unwrap().as_str();
-            let freq = caps.get(2).unwrap().as_str();
-            let freq = (f32::from_str(freq).unwrap() * 1_000_000.0) as u64;
+    // Some "legacy" functionality which allowed specifyin TRAFFIC options on separate lines
+    // extract optional traffic frequencies
+    let re = Regex::new(r"TRAFFIC ([a-zA-Z-]+) ([1-3]\d{2}(\.\d{1,3})?)").unwrap();
+    for caps in re.captures_iter(situation) {
+        let name = caps.get(1).unwrap().as_str();
+        let freq = caps.get(2).unwrap().as_str();
+        let freq = (f32::from_str(freq).unwrap() * 1_000_000.0) as u64;
 
-            if let Some(freqs) = stations.get_mut(name) {
-                freqs.traffic = Some(freq);
-            }
+        if let Some(freqs) = stations.get_mut(name) {
+            freqs.traffic = Some(freq);
         }
+    }
 
     stations
 }

--- a/crates/datis-core/src/station.rs
+++ b/crates/datis-core/src/station.rs
@@ -29,6 +29,7 @@ pub struct Airfield {
     pub traffic_freq: Option<u64>,
     pub info_ltr_offset: usize,
     pub info_ltr_override: Option<char>,
+    pub active_rwy_override: Option<String>
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -258,7 +259,11 @@ impl Airfield {
             self.name, information_letter, _break
         );
 
-        if let Some(rwy) = self.get_active_runway(weather.wind_dir) {
+        if let Some(rwy) = &self.active_rwy_override {
+            let rwy = pronounce_number(rwy, spoken);
+            report += &format!("Runway in use is {}. {}", rwy, _break);
+        }
+        else if let Some(rwy) = self.get_active_runway(weather.wind_dir) {
             let rwy = pronounce_number(rwy, spoken);
             report += &format!("Runway in use is {}. {}", rwy, _break);
         } else {
@@ -594,6 +599,7 @@ mod test {
             traffic_freq: None,
             info_ltr_offset: 0,
             info_ltr_override: None,
+            active_rwy_override: None,
         };
 
         assert_eq!(airfield.get_active_runway(0.0), Some("04"));
@@ -619,6 +625,7 @@ mod test {
                 traffic_freq: Some(249_500_000),
                 info_ltr_offset: 0,
                 info_ltr_override: None,
+                active_rwy_override: None,
             }),
         };
 
@@ -640,6 +647,7 @@ mod test {
                 traffic_freq: Some(249_500_000),
                 info_ltr_offset: 15, // Should be "Papa"
                 info_ltr_override: None,
+                active_rwy_override: None,
             }),
         };
 
@@ -661,6 +669,7 @@ mod test {
                 traffic_freq: Some(249_500_000),
                 info_ltr_offset: 15,
                 info_ltr_override: Some('Q'),
+                active_rwy_override: None,
             }),
         };
 
@@ -768,7 +777,7 @@ mod test {
                 unit_id: 42,
                 unit_name: "Weather Post".to_string(),
                 info_ltr_offset: 15, // Should be "Papa",
-                info_ltr_override: None,
+                info_ltr_override: None
             }),
         };
 

--- a/crates/datis-core/src/station.rs
+++ b/crates/datis-core/src/station.rs
@@ -216,6 +216,10 @@ impl Station {
 
 impl Airfield {
     fn get_active_runway(&self, wind_dir: f64) -> Option<&str> {
+        if let Some(rwy_override) = &self.active_rwy_override {
+            return Some(rwy_override);
+        }
+
         let lr: &[_] = &['L', 'R'];
         for rwy in &self.runways {
             let rwy = rwy.trim_matches(lr);
@@ -259,11 +263,7 @@ impl Airfield {
             self.name, information_letter, _break
         );
 
-        if let Some(rwy) = &self.active_rwy_override {
-            let rwy = pronounce_number(rwy, spoken);
-            report += &format!("Runway in use is {}. {}", rwy, _break);
-        }
-        else if let Some(rwy) = self.get_active_runway(weather.wind_dir) {
+        if let Some(rwy) = self.get_active_runway(weather.wind_dir) {
             let rwy = pronounce_number(rwy, spoken);
             report += &format!("Runway in use is {}. {}", rwy, _break);
         } else {

--- a/crates/datis-core/src/station.rs
+++ b/crates/datis-core/src/station.rs
@@ -29,7 +29,7 @@ pub struct Airfield {
     pub traffic_freq: Option<u64>,
     pub info_ltr_offset: usize,
     pub info_ltr_override: Option<char>,
-    pub active_rwy_override: Option<String>
+    pub active_rwy_override: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -777,7 +777,7 @@ mod test {
                 unit_id: 42,
                 unit_name: "Weather Post".to_string(),
                 info_ltr_offset: 15, // Should be "Papa",
-                info_ltr_override: None
+                info_ltr_override: None,
             }),
         };
 

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -72,6 +72,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
                     traffic_freq: None,
                     info_ltr_offset: rng.gen_range(0, 25),
                     info_ltr_override: None,
+                    active_rwy_override: None,
                 },
             );
         }
@@ -237,6 +238,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
             airfields.remove(&config.name).map(|mut airfield| {
                 airfield.traffic_freq = config.traffic;
                 airfield.info_ltr_override = config.info_ltr_override;
+                airfield.active_rwy_override = conbfig.active_rwy_override;
                 airfield.position.x = mission_unit.x;
                 airfield.position.y = mission_unit.y;
                 airfield.position.alt = mission_unit.alt;
@@ -359,6 +361,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
                     unit_name: mission_unit.name.clone(),
                     info_ltr_offset: rng.gen_range(0, 25),
                     info_ltr_override: None,
+                    active_rwy_override: None,
                 }),
                 rpc: Some(rpc.clone()),
             })

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -25,7 +25,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
 
     // extract frequencies from mission briefing, which is retrieved from
     // `DCS.getMissionDescription()`
-    let stationConfigsFromDescription = {
+    let station_configs_from_description = {
         let dcs: LuaTable<'_> = lua.globals().get("DCS")?;
         let mission_description: String = dcs.call_function("getMissionDescription", ())?;
         extract_stationc_config_from_mission_description(&mission_description)
@@ -218,7 +218,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
 
     // combine the frequencies that have extracted from the mission's situation with their
     // corresponding airfield
-    let mut stations: Vec<Station> = stationConfigsFromDescription
+    let mut stations: Vec<Station> = station_configs_from_description
         .into_iter()
         .filter_map(|(name, freq)| {
             airfields.remove(&name).map(|airfield| Station {
@@ -238,7 +238,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
             airfields.remove(&config.name).map(|mut airfield| {
                 airfield.traffic_freq = config.traffic;
                 airfield.info_ltr_override = config.info_ltr_override;
-                airfield.active_rwy_override = conbfig.active_rwy_override;
+                airfield.active_rwy_override = config.active_rwy_override;
                 airfield.position.x = mission_unit.x;
                 airfield.position.y = mission_unit.y;
                 airfield.position.alt = mission_unit.alt;
@@ -361,7 +361,6 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
                     unit_name: mission_unit.name.clone(),
                     info_ltr_offset: rng.gen_range(0, 25),
                     info_ltr_override: None,
-                    active_rwy_override: None,
                 }),
                 rpc: Some(rpc.clone()),
             })

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -25,10 +25,10 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
 
     // extract frequencies from mission briefing, which is retrieved from
     // `DCS.getMissionDescription()`
-    let frequencies = {
+    let stationConfigsFromDescription = {
         let dcs: LuaTable<'_> = lua.globals().get("DCS")?;
-        let mission_situation: String = dcs.call_function("getMissionDescription", ())?;
-        extract_atis_station_frequencies(&mission_situation)
+        let mission_description: String = dcs.call_function("getMissionDescription", ())?;
+        extract_stationc_config_from_mission_description(&mission_description)
     };
 
     // Create a random generator for creating the information letter offset.
@@ -218,7 +218,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
 
     // combine the frequencies that have extracted from the mission's situation with their
     // corresponding airfield
-    let mut stations: Vec<Station> = frequencies
+    let mut stations: Vec<Station> = stationConfigsFromDescription
         .into_iter()
         .filter_map(|(name, freq)| {
             airfields.remove(&name).map(|airfield| Station {

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -237,7 +237,7 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
         })
         .collect();
 
-    // check all units if they represent and ATIS station and if so, combine them with
+    // check all units if they represent an ATIS station and if so, combine them with
     // their corresponding airfield
     stations.extend(mission_units.iter().filter_map(|mission_unit| {
         extract_atis_station_config(&mission_unit.name).and_then(|config| {

--- a/crates/datis-module/src/mission.rs
+++ b/crates/datis-module/src/mission.rs
@@ -220,13 +220,19 @@ pub fn extract(lua: &Lua) -> Result<Info, mlua::Error> {
     // corresponding airfield
     let mut stations: Vec<Station> = station_configs_from_description
         .into_iter()
-        .filter_map(|(name, freq)| {
-            airfields.remove(&name).map(|airfield| Station {
-                name,
-                freq: freq.atis,
-                tts: default_voice.clone(),
-                transmitter: Transmitter::Airfield(airfield),
-                rpc: Some(rpc.clone()),
+        .filter_map(|(name, config)| {
+            airfields.remove(&name).map(|mut airfield| {
+                airfield.traffic_freq = config.traffic;
+                airfield.info_ltr_override = config.info_ltr_override;
+                airfield.active_rwy_override = config.active_rwy_override;
+
+                Station {
+                    name,
+                    freq: config.atis,
+                    tts: default_voice.clone(),
+                    transmitter: Transmitter::Airfield(airfield),
+                    rpc: Some(rpc.clone()),
+                }
             })
         })
         .collect();


### PR DESCRIPTION
Allow the more advanced ATIS options to be specified via the mission description.  Uses the same parser as the static unit name, which should reduce complexity going forward when/if more options are added.